### PR TITLE
Update to gnome 42

### DIFF
--- a/bluetooth.js
+++ b/bluetooth.js
@@ -18,46 +18,52 @@ const GnomeBluetooth = imports.gi.GnomeBluetooth;
 const Signals = imports.signals;
 const GLib = imports.gi.GLib;
 const ExtensionUtils = imports.misc.extensionUtils;
-const Utils = ExtensionUtils.getCurrentExtension().imports.utils;
-const Log = ExtensionUtils.getCurrentExtension().imports.buds.Log;
+const Me = ExtensionUtils.getCurrentExtension();
+const Utils = Me.imports.utils;
 
 var BluetoothController = class {
     constructor() {
         this._client = new GnomeBluetooth.Client();
-        this._model = this._client.get_model();
+        this._deviceNotifyConnected = new Set();
+        this._store = this._client.get_devices();
     }
 
     enable() {
-        this._connectSignal(this._model, 'row-changed', (arg0, arg1, iter) => {
-            if (iter) {
-                let device = this._buildDevice(iter);
-                this.emit('device-changed', device);
-            }
-
+        this._client.connect('notify::default-adapter', () => {
+            this._deviceNotifyConnected.clear();
+            this.emit('default-adapter-changed');
         });
-        this._connectSignal(this._model, 'row-deleted', () => {
+        this._client.connect('notify::default-adapter-powered', () => {
+            this._deviceNotifyConnected.clear();
+            this.emit('default-adapter-changed');
+        });
+        this._client.connect('device-removed', (c, path) => {
+            this._deviceNotifyConnected.delete(path);
             this.emit('device-deleted');
         });
-        this._connectSignal(this._model, 'row-inserted', (arg0, arg1, iter) => {
-            if (iter) {
-                let device = this._buildDevice(iter);
-                this.emit('device-inserted', device);
-            }
+        this._client.connect('device-added', (c, device) => {
+            this._connectDeviceNotify(device);
+            this.emit('device-inserted', new BluetoothDevice(device));
+        });
+    }
+
+    _connectDeviceNotify(device) {
+        const path = device.get_object_path();
+
+        if (this._deviceNotifyConnected.has(path))
+            return;
+
+        device.connect('notify', (device) => {
+            this.emit('device-changed', new BluetoothDevice(device));
         });
     }
 
     getDevices() {
-        let adapter = this._getDefaultAdapter();
-        if (!adapter){
-            Log("No adapter found.")
-            return [];
-        }
         let devices = [];
-        let [ret, iter] = this._model.iter_children(adapter);
-        while (ret) {
-            let device = this._buildDevice(iter);
+
+        for (let i = 0; i < this._store.get_n_items(); i++) {
+            let device = new BluetoothDevice(this._store.get_item(i));
             devices.push(device);
-            ret = this._model.iter_next(iter);
         }
 
         return devices;
@@ -72,50 +78,32 @@ var BluetoothController = class {
     destroy() {
         this._disconnectSignals();
     }
-
-    _getDefaultAdapter() {
-        let [ret, iter] = this._model.get_iter_first();
-        while (ret) {
-            let isDefault = this._model.get_value(iter, GnomeBluetooth.Column.DEFAULT);
-            let isPowered = this._model.get_value(iter, GnomeBluetooth.Column.POWERED);
-            if (isDefault && isPowered)
-                return iter;
-            ret = this._model.iter_next(iter);
-        }
-        return null;
-    }
-
-    _buildDevice(iter) {
-        return new BluetoothDevice(this._model, iter);
-    }
 }
 
 Signals.addSignalMethods(BluetoothController.prototype);
 Utils.addSignalsHelperMethods(BluetoothController.prototype);
 
 var BluetoothDevice = class {
-    constructor(model, iter) {
-        this._model = model;
-        this.update(iter);
+    constructor(dev) {
+        this.update(dev);
     }
 
-    update(iter) {
-        this.name = this._model.get_value(iter, GnomeBluetooth.Column.NAME);
-        this.isConnected = this._model.get_value(iter, GnomeBluetooth.Column.CONNECTED);
-        this.isPaired = this._model.get_value(iter, GnomeBluetooth.Column.PAIRED);
-        this.mac = this._model.get_value(iter, GnomeBluetooth.Column.ADDRESS);
-        this.isDefault = this._model.get_value(iter, GnomeBluetooth.Column.DEFAULT);
+    update(dev) {
+        this.name = dev.alias || dev.name;
+        this.isConnected = dev.connected;
+        this.isPaired = dev.paired;
+        this.mac = dev.address;
     }
 
-    disconnect(callback) {
-        Utils.spawn(`bluetoothctl -- disconnect ${this.mac}`, callback)
+    disconnect() {
+        Utils.spawn(`bluetoothctl -- disconnect ${this.mac}`)
     }
 
-    connect(callback) {
-        Utils.spawn(`bluetoothctl -- connect ${this.mac}`, callback)
+    connect() {
+        Utils.spawn(`bluetoothctl -- connect ${this.mac}`)
     }
 
-    reconnect(callback) {
-        Utils.spawn(`bluetoothctl -- disconnect ${this.mac} && bluetoothctl -- connect ${this.mac}`, callback)
+    reconnect() {
+        Utils.spawn(`bluetoothctl -- disconnect ${this.mac} && sleep 7 && bluetoothctl -- connect ${this.mac}`)
     }
 }

--- a/buds.js
+++ b/buds.js
@@ -1,5 +1,5 @@
 const Lang = imports.lang;
-const { St, Gio } = imports.gi;
+const { St, Gio, GObject } = imports.gi;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const GLib = imports.gi.GLib;
@@ -9,7 +9,7 @@ const DEBUG = true;
 
 function execCommunicate(argv) {
     let flags = (Gio.SubprocessFlags.STDOUT_PIPE |
-                 Gio.SubprocessFlags.STDERR_PIPE);
+        Gio.SubprocessFlags.STDERR_PIPE);
 
     let proc = Gio.Subprocess.new(argv, flags);
     return new Promise((resolve, reject) => {
@@ -33,120 +33,116 @@ function execCommunicate(argv) {
     });
 }
 
-var budsBattIndicator = new Lang.Class({
-
-	Name : "BtGalaxyBudsBattIndicator",
-	Extends: PanelMenu.Button,
-
-	_init: function () {
-		Log("Init budsBattIndicator");
-		this.parent(0.0, "btGalaxyBudsBattIndicator");
-		this.batteryStatusArray = ["N/A","N/A","N/A"];
-		var hbox = new St.BoxLayout({ style_class: 'panel-status-menu-box bt-buds-batt-hbox' });
-		this.icon = new St.Icon({
+var budsBattIndicator = GObject.registerClass({
+    GTypeName: 'BtGalaxyBudsBattIndicator',
+}, class BtGalaxyBudsBattIndicator extends PanelMenu.Button {
+    constructor() {
+        Log("Init budsBattIndicator");
+        super(0.0, "btGalaxyBudsBattIndicator");
+        this.batteryStatusArray = ["N/A", "N/A", "N/A"];
+        var hbox = new St.BoxLayout({style_class: 'panel-status-menu-box bt-buds-batt-hbox'});
+        this.icon = new St.Icon({
             style_class: 'system-status-icon'
         });
-        this.icon.gicon = Gio.icon_new_for_string(imports.misc.extensionUtils.getCurrentExtension().path+"/icons/buds.svg");
-		hbox.add_child(this.icon);
+        this.icon.gicon = Gio.icon_new_for_string(imports.misc.extensionUtils.getCurrentExtension().path + "/icons/buds.svg");
+        hbox.add_child(this.icon);
 
-		this.buttonText = new St.Label({
-				text: _('%'),
-				y_align: Clutter.ActorAlign.CENTER,
-				x_align: Clutter.ActorAlign.START
-		});
-		hbox.add_child(this.buttonText);
-		this.add_child(hbox);
-		this.case = new PopupMenu.PopupMenuItem("",{reactive : false});
-		this.buds = new PopupMenu.PopupMenuItem("",{reactive : false});
-		this.buds.add_child(new St.Icon({
-			gicon : Gio.icon_new_for_string(imports.misc.extensionUtils.getCurrentExtension().path+"/icons/left.svg"),
-			icon_size : 32,
-		}));
-		this.leftLabel  = new St.Label({text : 'NA%', y_align: Clutter.ActorAlign.CENTER,});
-		this.buds.add_child(this.leftLabel);
-		this.buds.add_child(new St.Label({text : '   ', y_align: Clutter.ActorAlign.CENTER,}));
-		this.rightLabel  = new St.Label({text : 'NA%', y_align: Clutter.ActorAlign.CENTER,});
-		this.buds.add_child(this.rightLabel);
-		this.buds.add_child(new St.Icon({
-			gicon : Gio.icon_new_for_string(imports.misc.extensionUtils.getCurrentExtension().path+"/icons/right.svg"),
-			icon_size : 32,
-		}));
-		this.case.add_child(new St.Label({text : '       ', y_align: Clutter.ActorAlign.CENTER,}));
-		this.case.add_child(new St.Icon({
-			gicon : Gio.icon_new_for_string(imports.misc.extensionUtils.getCurrentExtension().path+"/icons/case.svg"),
-			icon_size : 45,
-			y_align: Clutter.ActorAlign.CENTER,
-		}));
-		this.caseLabel  = new St.Label({text : 'NA%', y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.CENTER,});
-		this.case.add_child(this.caseLabel);
-		this.menu.addMenuItem(this.buds);
-		this.menu.addMenuItem(this.case);
-		Main.panel.addToStatusArea('BtGalaxyBudsBattIndicator', this, 1);
-		this.hide();
-		this.enabled = false;
-	},
+        this.buttonText = new St.Label({
+            text: _('%'),
+            y_align: Clutter.ActorAlign.CENTER,
+            x_align: Clutter.ActorAlign.START
+        });
+        hbox.add_child(this.buttonText);
+        this.add_child(hbox);
+        this.case = new PopupMenu.PopupMenuItem("", {reactive: false});
+        this.buds = new PopupMenu.PopupMenuItem("", {reactive: false});
+        this.buds.add_child(new St.Icon({
+            gicon: Gio.icon_new_for_string(imports.misc.extensionUtils.getCurrentExtension().path + "/icons/left.svg"),
+            icon_size: 32,
+        }));
+        this.leftLabel = new St.Label({text: 'NA%', y_align: Clutter.ActorAlign.CENTER, });
+        this.buds.add_child(this.leftLabel);
+        this.buds.add_child(new St.Label({text: '   ', y_align: Clutter.ActorAlign.CENTER, }));
+        this.rightLabel = new St.Label({text: 'NA%', y_align: Clutter.ActorAlign.CENTER, });
+        this.buds.add_child(this.rightLabel);
+        this.buds.add_child(new St.Icon({
+            gicon: Gio.icon_new_for_string(imports.misc.extensionUtils.getCurrentExtension().path + "/icons/right.svg"),
+            icon_size: 32,
+        }));
+        this.case.add_child(new St.Label({text: '       ', y_align: Clutter.ActorAlign.CENTER, }));
+        this.case.add_child(new St.Icon({
+            gicon: Gio.icon_new_for_string(imports.misc.extensionUtils.getCurrentExtension().path + "/icons/case.svg"),
+            icon_size: 45,
+            y_align: Clutter.ActorAlign.CENTER,
+        }));
+        this.caseLabel = new St.Label({text: 'NA%', y_align: Clutter.ActorAlign.CENTER, x_align: Clutter.ActorAlign.CENTER, });
+        this.case.add_child(this.caseLabel);
+        this.menu.addMenuItem(this.buds);
+        this.menu.addMenuItem(this.case);
+        Main.panel.addToStatusArea('BtGalaxyBudsBattIndicator', this, 1);
+        this.hide();
+        this.enabled = false;
+    }
 
-	enable(macAdress){
-		Log("Enable budsBattIndicator");
-		if (!this.enabled) {
-			this.show();
-			this.enabled = true;
-			this.syncBattery(macAdress);
-			this.event = GLib.timeout_add_seconds(0, 180,  () => {
-				this.syncBattery(macAdress);
-				return true;
-			});
-		}
-	},
+    enable(macAddress) {
+        Log("Enable budsBattIndicator");
+        if (!this.enabled) {
+            this.show();
+            this.enabled = true;
+            this.syncBattery(macAddress);
+            this.event = GLib.timeout_add_seconds(0, 180, () => {
+                this.syncBattery(macAddress);
+                return true;
+            });
+        }
+    }
 
-	disable(){
-		Log("Disable budsBattIndicator");
-		if (this.enabled){
-			this.hide();
-			GLib.Source.remove(this.event);
-			this.enabled = false;
-		}
-	},
+    disable() {
+        Log("Disable budsBattIndicator");
+        if (this.enabled) {
+            this.hide();
+            GLib.Source.remove(this.event);
+            this.enabled = false;
+        }
+    }
 
-	syncBattery : function(macAdress) {
-		if (this.enabled) {
-			Log("Sync budsBattIndicator");
-			let argv = [imports.misc.extensionUtils.getCurrentExtension().path+"/buds_battery.py", macAdress+''];
-			execCommunicate(argv).then(result => {
-				var [leftBatt, rightBatt, caseBatt] = ["N/A","N/A","N/A"];
-				[leftBatt, rightBatt, caseBatt] = result.split(','); 
-				
-				this.leftLabel.set_text(leftBatt + "%");
-				this.rightLabel.set_text(rightBatt + "%");
-				if (typeof caseBatt !== 'undefined') {
-					this.caseLabel.set_text(caseBatt.trimEnd() + "%");
-				} else {
-					this.case.hide();
-				}
-				if (parseInt(rightBatt) == 0) {
-					this.buttonText.set_text(leftBatt + "%");
-				} else if (parseInt(leftBatt) == 0) { 
-					this.buttonText.set_text(rightBatt + "%");
-			    } else if (parseInt(rightBatt) <= parseInt(leftBatt)){
-					this.buttonText.set_text(rightBatt + "%");
-				} else  {
-					this.buttonText.set_text(leftBatt + "%");
-				}
-				
-			}).catch (e => {
-				Log(e);
-				this.hide();
-			});
-		}
-	},
+    syncBattery(macAddress) {
+        if (this.enabled) {
+            Log("Sync budsBattIndicator");
+            let argv = [imports.misc.extensionUtils.getCurrentExtension().path + "/buds_battery.py", macAddress + ''];
+            execCommunicate(argv).then(result => {
+                var [leftBatt, rightBatt, caseBatt] = ["N/A", "N/A", "N/A"];
+                [leftBatt, rightBatt, caseBatt] = result.split(',');
 
-	reset : function (){
-		Log("Reset budsBattIndicator");
-		this.buds.destroy();
-		this.case.destroy();
-	},
-	
-	
+                this.leftLabel.set_text(leftBatt + "%");
+                this.rightLabel.set_text(rightBatt + "%");
+                if (typeof caseBatt !== 'undefined') {
+                    this.caseLabel.set_text(caseBatt.trimEnd() + "%");
+                } else {
+                    this.case.hide();
+                }
+                if (parseInt(rightBatt) == 0) {
+                    this.buttonText.set_text(leftBatt + "%");
+                } else if (parseInt(leftBatt) == 0) {
+                    this.buttonText.set_text(rightBatt + "%");
+                } else if (parseInt(rightBatt) <= parseInt(leftBatt)) {
+                    this.buttonText.set_text(rightBatt + "%");
+                } else {
+                    this.buttonText.set_text(leftBatt + "%");
+                }
+
+            }).catch(e => {
+                Log(e);
+                this.hide();
+            });
+        }
+    }
+
+    reset() {
+        Log("Reset budsBattIndicator");
+        this.buds.destroy();
+        this.case.destroy();
+    }
 });
 
 var Log = function(msg) {

--- a/metadata.json
+++ b/metadata.json
@@ -2,9 +2,9 @@
   "description": "Galaxy Buds battery indicator.",
   "name": "Galaxy Buds Battery",
   "shell-version": [
-    "3.36", "3.38"
+      "42"
   ],
   "url": "https://github.com/pemmoura/galaxybuds-gnome-extension",
   "uuid": "galaxy-buds-battery@pemmoura",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
I made some changes to update the extension to support GNOME 42. Namely:

- Update `buds.js` from Legacy Class Syntax to ES6 classes
- Update `bluetooth.js` from using GnomeBluetooth 1.0 to GnomeBluetooth 3.0 with the script by [bjarosze](https://github.com/bjarosze/gnome-bluetooth-quick-connect/blob/cd281626d6c711430cf2ba00783ced291c2f9aa6/bluetooth.js)
- Fixed a typo in `buds.js`: "adress" > "address"

Unfortunately, because of the changes with the ES6 classes, I had to disable the support for older GNOME Versions (3.36 and 3.38).